### PR TITLE
don't consider tags that are not semver

### DIFF
--- a/internal/git.go
+++ b/internal/git.go
@@ -17,6 +17,10 @@ func GitTagMap(repo git.Repository) (*map[string]string, error) {
 	tagMap := map[string]string{}
 	err = iter.ForEach(func(r *plumbing.Reference) error {
 		tag, _ := repo.TagObject(r.Hash())
+		if SemVerParse(r.Name().Short()) == nil {
+			// Filter out tags that are not semver
+			return nil
+		}
 		if tag == nil {
 			tagMap[r.Hash().String()] = r.Name().Short()
 		} else {

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -43,6 +43,21 @@ func TestGitTagMap(t *testing.T) {
 		commit1.String(): "v1.0.0",
 		commit2.String(): "v2.0.0",
 	}, *tags)
+
+	commit3, _ := worktree.Commit("third", &git.CommitOptions{Author: &author})
+	tag3, _ := repo.CreateTag("fum", commit3, &git.CreateTagOptions{
+		Tagger: &object.Signature{
+			Name:  "Fum",
+			Email: "fum@example.com",
+		},
+		Message: "Not a semver version tag",
+	})
+	assert.NotEqual(commit3.String(), tag3.Hash().String())
+	tags, _ = GitTagMap(*repo)
+	assert.Equal(map[string]string{
+		commit1.String(): "v1.0.0",
+		commit2.String(): "v2.0.0",
+	}, *tags)
 }
 
 func TestGitDescribe(t *testing.T) {


### PR DESCRIPTION
This is useful in a repository that contains tags that are not meant to be release tags