### PR TITLE
Support git repository checkouts using `git worktree`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,11 +8,10 @@ import (
 	"time"
 
 	"github.com/choffmeister/git-describe-semver/internal"
-	"github.com/go-git/go-git/v5"
 )
 
 func run(dir string, opts internal.GenerateVersionOptions) (*string, error) {
-	repo, err := git.PlainOpen(dir)
+	repo, err := internal.OpenRepository(dir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open git repository: %v", err)
 	}

--- a/internal/git.go
+++ b/internal/git.go
@@ -1,11 +1,23 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+const (
+	// Prefix found in .git files that point to another location
+	GitDirPrefix = "gitdir: "
+
+	GitDirName    = ".git"
+	CommonDirName = "commondir"
 )
 
 // GitTagMap ...
@@ -98,4 +110,57 @@ func GitDescribe(repo git.Repository) (*string, *int, *string, error) {
 	}
 	tagName := (*tags)[tagHash]
 	return &tagName, &counter, &headHash, nil
+}
+
+func OpenRepository(dir string) (*git.Repository, error) {
+	gitDir, err := FindGitDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	enableCommonDir, err := shouldEnableCommondDir(gitDir)
+	if err != nil {
+		return nil, err
+	}
+	openOpts := &git.PlainOpenOptions{EnableDotGitCommonDir: enableCommonDir}
+	return git.PlainOpenWithOptions(dir, openOpts)
+}
+
+func shouldEnableCommondDir(gitDir string) (bool, error) {
+	cdPath := filepath.Join(gitDir, CommonDirName)
+	st, err := os.Stat(cdPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if st.IsDir() {
+		return false, fmt.Errorf("expected to be a file, not directory: %s", cdPath)
+	}
+	return true, nil
+}
+
+func FindGitDir(dir string) (string, error) {
+	gitDirPath := filepath.Join(dir, GitDirName)
+	st, err := os.Stat(gitDirPath)
+	if err != nil {
+		return "", err
+	}
+	if st.IsDir() {
+		return gitDirPath, nil
+	}
+	// It is a file, read the contents
+	contents, err := os.ReadFile(gitDirPath)
+	if err != nil {
+		return "", err
+	}
+
+	line := string(contents)
+	if !strings.HasPrefix(line, GitDirPrefix) {
+		return "", fmt.Errorf(".git file has no %s prefix", GitDirPrefix)
+	}
+
+	gitdir := strings.Split(line[len(GitDirPrefix):], "\n")[0]
+	gitdir = strings.TrimSpace(gitdir)
+	return gitdir, nil
 }

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -111,4 +113,82 @@ func TestGitDescribeWithBranch(t *testing.T) {
 	test("v1.0.0", 2, commit4.String())
 	repo.CreateTag("v2.0.0", commit3, nil)
 	test("v2.0.0", 1, commit4.String())
+}
+
+func setUpDotGitDirTest(assert *assert.Assertions) (string, string) {
+	testDir, err := os.MkdirTemp("", "test")
+	assert.NoError(err, "failed to create temp dir")
+
+	gitDirPath := filepath.Join(testDir, GitDirName)
+	err = os.Mkdir(gitDirPath, 0750)
+	assert.NoError(err, "failed to create git dir")
+
+	return testDir, gitDirPath
+}
+
+func setUpDotGitFileTest(assert *assert.Assertions) (string, string, string) {
+	testDir, err := os.MkdirTemp("", "test")
+	assert.NoError(err, "failed to create temp dir")
+
+	actualDotGitPath := filepath.Join(testDir, "actual")
+	err = os.Mkdir(actualDotGitPath, 0750)
+	assert.NoError(err, "failed to create actual git dir")
+
+	wtPath := filepath.Join(testDir, "my_worktree")
+	err = os.Mkdir(wtPath, 0750)
+	assert.NoError(err, "failed to create worktree dir")
+
+	wtDotGitPath := filepath.Join(wtPath, GitDirName)
+	contents := GitDirPrefix + actualDotGitPath
+	err = os.WriteFile(wtDotGitPath, []byte(contents), 0666)
+	assert.NoError(err, "failed to write git dir file in worktree")
+
+	return testDir, actualDotGitPath, wtPath
+}
+
+func TestFindGitDir(t *testing.T) {
+	t.Run(".git is a directory", func(t *testing.T) {
+		assert := assert.New(t)
+		testDir, gitDirPath := setUpDotGitDirTest(assert)
+		defer os.RemoveAll(testDir)
+
+		result, err := FindGitDir(testDir)
+		assert.NoError(err, "failed to find git dir")
+		assert.Equal(gitDirPath, result)
+	})
+	t.Run(".git is a file pointing to another directory", func(t *testing.T) {
+		assert := assert.New(t)
+		testDir, actualDotGitPath, wtPath := setUpDotGitFileTest(assert)
+		defer os.RemoveAll(testDir)
+
+		result, err := FindGitDir(wtPath)
+		assert.NoError(err, "failed to find git dir in worktree")
+		assert.Equal(actualDotGitPath, result)
+	})
+}
+
+func TestShouldEnableCommonDir(t *testing.T) {
+	t.Run(".git is a directory", func(t *testing.T) {
+		assert := assert.New(t)
+		testDir, gitDirPath := setUpDotGitDirTest(assert)
+		defer os.RemoveAll(testDir)
+
+		result, err := shouldEnableCommondDir(gitDirPath)
+		assert.NoError(err, "failed evaluating whether to enable commond dir")
+		assert.False(result)
+	})
+	t.Run(".git is a file pointing to another directory", func(t *testing.T) {
+		assert := assert.New(t)
+		testDir, actualDotGitPath, _ := setUpDotGitFileTest(assert)
+		defer os.RemoveAll(testDir)
+
+		cdPath := filepath.Join(actualDotGitPath, CommonDirName)
+		contents := "../my_worktree"
+		err := os.WriteFile(cdPath, []byte(contents), 0666)
+		assert.NoError(err, "failed writing commondir file")
+
+		result, err := shouldEnableCommondDir(actualDotGitPath)
+		assert.NoError(err, "failed evaluating whether to enable commond dir")
+		assert.True(result)
+	})
 }


### PR DESCRIPTION
When working with repository code using git worktree, the worktree's .git is a file that references the location of the worktree's git files. This location (i.e., directory) only contains pertinent data for that worktree. In addition, it has a file called commondir that specifies the location of the rest of the repository files.

This PR updates git-descrive-semver to identify whether the current worktree uses the commondir mechanism. If so, it enables support for this mechanism in go-git.